### PR TITLE
fish: support quoted values

### DIFF
--- a/example/cmd/root_test.go
+++ b/example/cmd/root_test.go
@@ -171,18 +171,30 @@ complete -F _example_completions example
 }
 
 func TestFish(t *testing.T) {
-	expected := `function _example_state
+	expected := `function _example_quote_suffix
+  if not commandline -cp | xargs echo 2>/dev/null >/dev/null
+    if commandline -cp | sed 's/$/"/'| xargs echo 2>/dev/null >/dev/null
+      echo '"'
+    else if commandline -cp | sed "s/\$/'/"| xargs echo 2>/dev/null >/dev/null
+      echo "'"
+    end
+  else 
+    echo ""
+  end
+end
+
+function _example_state
   set -lx CURRENT (commandline -cp)
   if [ "$LINE" != "$CURRENT" ]
     set -gx LINE (commandline -cp)
-    set -gx STATE (commandline -cp | xargs example _carapace fish state)
+    set -gx STATE (commandline -cp | sed "s/\$/"(_example_quote_suffix)"/" | xargs example _carapace fish state)
   end
 
   [ "$STATE" = "$argv" ]
 end
 
 function _example_callback
-  set -lx CALLBACK (commandline -cp | sed "s/ \$/ _/" | xargs example _carapace fish $argv )
+  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_example_quote_suffix)"/" | sed "s/ \$/ _/" | xargs example _carapace fish $argv )
   eval "$CALLBACK"
 end
 

--- a/fish/snippet.go
+++ b/fish/snippet.go
@@ -18,23 +18,35 @@ var replacer = strings.NewReplacer(
 )
 
 func Snippet(cmd *cobra.Command, actions map[string]string) string {
-	result := fmt.Sprintf(`function _%v_state
+	result := fmt.Sprintf(`function _%v_quote_suffix
+  if not commandline -cp | xargs echo 2>/dev/null >/dev/null
+    if commandline -cp | sed 's/$/"/'| xargs echo 2>/dev/null >/dev/null
+      echo '"'
+    else if commandline -cp | sed "s/\$/'/"| xargs echo 2>/dev/null >/dev/null
+      echo "'"
+    end
+  else 
+    echo ""
+  end
+end
+
+function _%v_state
   set -lx CURRENT (commandline -cp)
   if [ "$LINE" != "$CURRENT" ]
     set -gx LINE (commandline -cp)
-    set -gx STATE (commandline -cp | xargs %v _carapace fish state)
+    set -gx STATE (commandline -cp | sed "s/\$/"(_%v_quote_suffix)"/" | xargs %v _carapace fish state)
   end
 
   [ "$STATE" = "$argv" ]
 end
 
 function _%v_callback
-  set -lx CALLBACK (commandline -cp | sed "s/ \$/ _/" | xargs %v _carapace fish $argv )
+  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_%v_quote_suffix)"/" | sed "s/ \$/ _/" | xargs %v _carapace fish $argv )
   eval "$CALLBACK"
 end
 
 complete -c %v -f
-`, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name())
+`, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name())
 	result += snippetFunctions(cmd, actions)
 
 	return result


### PR DESCRIPTION
- commandline can tokenize with '-t' but that removes quotes so
  simply check xargs for error to decide which quote to add

related #6 