### PR TITLE
bash: fix parameter expansion

### DIFF
--- a/bash/snippet.go
+++ b/bash/snippet.go
@@ -16,7 +16,7 @@ _%v_callback() {
   local last="${COMP_WORDS[${COMP_CWORD}]}"
   if [[ $last =~ ^[\"\'] ]] && ! echo "$last" | xargs echo 2>/dev/null >/dev/null ; then
       compline="${compline}${last:0:1}"
-      last="${last/ /\\\\ }" 
+      last="${last// /\\\\ }" 
   fi
 
   echo "$compline" | sed -e 's/ $/ _/' -e 's/"/\"/g' | xargs %v _carapace bash "$1"
@@ -28,9 +28,9 @@ _%v_completions() {
   
   if [[ $last =~ ^[\"\'] ]] && ! echo "$last" | xargs echo 2>/dev/null >/dev/null ; then
       compline="${compline}${last:0:1}"
-      last="${last/ /\\\\ }" 
+      last="${last// /\\\\ }" 
   else
-      last="${last/ /\\\ }" 
+      last="${last// /\\\ }" 
   fi
 
   local state=$(echo "$compline" | sed -e "s/ \$/ _/" -e 's/"/\"/g' | xargs %v _carapace bash state)
@@ -41,7 +41,7 @@ _%v_completions() {
 %v
   esac
 
-  [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]/\\ /\ }")
+  [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
   [[ $COMPREPLY == */ ]] && compopt -o nospace
 }
 

--- a/example/cmd/root_test.go
+++ b/example/cmd/root_test.go
@@ -14,7 +14,7 @@ _example_callback() {
   local last="${COMP_WORDS[${COMP_CWORD}]}"
   if [[ $last =~ ^[\"\'] ]] && ! echo "$last" | xargs echo 2>/dev/null >/dev/null ; then
       compline="${compline}${last:0:1}"
-      last="${last/ /\\\\ }" 
+      last="${last// /\\\\ }" 
   fi
 
   echo "$compline" | sed -e 's/ $/ _/' -e 's/"/\"/g' | xargs example _carapace bash "$1"
@@ -26,9 +26,9 @@ _example_completions() {
   
   if [[ $last =~ ^[\"\'] ]] && ! echo "$last" | xargs echo 2>/dev/null >/dev/null ; then
       compline="${compline}${last:0:1}"
-      last="${last/ /\\\\ }" 
+      last="${last// /\\\\ }" 
   else
-      last="${last/ /\\\ }" 
+      last="${last// /\\\ }" 
   fi
 
   local state=$(echo "$compline" | sed -e "s/ \$/ _/" -e 's/"/\"/g' | xargs example _carapace bash state)
@@ -162,7 +162,7 @@ _example_completions() {
 
   esac
 
-  [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]/\\ /\ }")
+  [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
   [[ $COMPREPLY == */ ]] && compopt -o nospace
 }
 


### PR DESCRIPTION
repeated substitution needs a double slash

related #6 