### PR TITLE
initial standalone support

### DIFF
--- a/bash/snippet.go
+++ b/bash/snippet.go
@@ -47,7 +47,7 @@ _%v_completions() {
 }
 
 complete -F _%v_completions %v
-`, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), snippetFunctions(cmd, actions), cmd.Name(), cmd.Name())
+`, cmd.Name(), uid.Executable(), cmd.Name(), uid.Executable(), snippetFunctions(cmd, actions), cmd.Name(), cmd.Name())
 
 	return result
 }
@@ -82,7 +82,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 	})
 
 	var positionalAction string
-	if cmd.HasSubCommands() {
+	if cmd.HasAvailableSubCommands() {
 		subcommands := make([]string, 0)
 		for _, c := range cmd.Commands() {
 			if !c.Hidden {

--- a/carapace.go
+++ b/carapace.go
@@ -91,6 +91,15 @@ func (c Carapace) Zsh() string {
 	return zsh.Snippet(c.cmd.Root(), actions)
 }
 
+func (c Carapace) Standalone() {
+	// TODO probably needs to be done for each subcommand
+	if c.cmd.Root().Flag("help") != nil {
+		c.cmd.Root().Flags().Bool("help", false, "skip")
+		c.cmd.Root().Flag("help").Hidden = true
+	}
+	c.cmd.Root().SetHelpCommand(&cobra.Command{Hidden: true})
+}
+
 func (c Carapace) Snippet(shell string) string {
 	switch shell {
 	case "bash":

--- a/elvish/snippet.go
+++ b/elvish/snippet.go
@@ -38,7 +38,7 @@ func Snippet(cmd *cobra.Command, actions map[string]string) string {
   if (eq 1 0) {
   } %v
 }
-`, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), snippetFunctions(cmd, actions))
+`, cmd.Name(), cmd.Name(), uid.Executable(), cmd.Name(), cmd.Name(), cmd.Name(), uid.Executable(), snippetFunctions(cmd, actions))
 
 	return result
 }
@@ -71,7 +71,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 	})
 
 	var positionals []string
-	if cmd.HasSubCommands() {
+	if cmd.HasAvailableSubCommands() {
 		subcommands := make([]string, 0)
 		for _, c := range cmd.Commands() {
 			if !c.Hidden {

--- a/example/cmd/root_test.go
+++ b/example/cmd/root_test.go
@@ -678,14 +678,14 @@ function _example__action {
 
 function _example__callback {
     _arguments -C \
-    "(-c --callback)"{-c,--callback}"[Help message for callback]: : eval \$(${os_args[1]} _carapace zsh '_example__callback##callback' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})" \
-    "1:: : eval \$(${os_args[1]} _carapace zsh '_example__callback#1' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})"
+    "(-c --callback)"{-c,--callback}"[Help message for callback]: : eval \$(example _carapace zsh '_example__callback##callback' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})" \
+    "1:: : eval \$(example _carapace zsh '_example__callback#1' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})"
 }
 
 function _example__condition {
     _arguments -C \
     "(-r --required)"{-r,--required}"[required flag]: :_values '' valid invalid" \
-    "1:: : eval \$(${os_args[1]} _carapace zsh '_example__condition#1' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})"
+    "1:: : eval \$(example _carapace zsh '_example__condition#1' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})"
 }
 
 function _example__help {

--- a/fish/snippet.go
+++ b/fish/snippet.go
@@ -46,7 +46,7 @@ function _%v_callback
 end
 
 complete -c %v -f
-`, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name())
+`, cmd.Name(), cmd.Name(), cmd.Name(), uid.Executable(), cmd.Name(), cmd.Name(), uid.Executable(), cmd.Name())
 	result += snippetFunctions(cmd, actions)
 
 	return result
@@ -72,11 +72,11 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 	})
 
 	positionals := make([]string, 0)
-	if cmd.HasSubCommands() {
+	if cmd.HasAvailableSubCommands() {
 		positionals = []string{}
 		for _, subcmd := range cmd.Commands() {
 			if !subcmd.Hidden {
-				positionals = append(positionals, fmt.Sprintf(`complete -c %v -f -n '_%v_state %v ' -a '%v' -d '%v'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), subcmd.Name()+" "+strings.Join(subcmd.Aliases, " "), subcmd.Short))
+				positionals = append(positionals, fmt.Sprintf(`complete -c %v -f -n '_%v_state %v ' -a '%v' -d '%v'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), subcmd.Name()+" "+strings.Join(subcmd.Aliases, " "), replacer.Replace(subcmd.Short)))
 			}
 		}
 	} else {
@@ -130,7 +130,7 @@ func zshCompFlagCouldBeSpecifiedMoreThenOnce(f *pflag.Flag) bool {
 }
 
 func snippetSubcommands(cmd *cobra.Command) string {
-	if !cmd.HasSubCommands() {
+	if !cmd.HasAvailableSubCommands() {
 		return ""
 	}
 	cmnds := make([]string, 0)

--- a/powershell/snippet.go
+++ b/powershell/snippet.go
@@ -16,7 +16,7 @@ func Snippet(cmd *cobra.Command, actions map[string]string) string {
 
 	var subCommandCases bytes.Buffer
 	generatePowerShellSubcommandCases(&subCommandCases, cmd, actions)
-	fmt.Fprintf(buf, powerShellCompletionTemplate, cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), cmd.Name(), subCommandCases.String())
+	fmt.Fprintf(buf, powerShellCompletionTemplate, cmd.Name(), uid.Executable(), cmd.Name(), uid.Executable(), uid.Executable(), subCommandCases.String())
 
 	return buf.String()
 }
@@ -118,7 +118,7 @@ func snippetTODO(cmd *cobra.Command) string {
 		}
 	}
 
-	if !cmd.HasSubCommands() {
+	if !cmd.HasAvailableSubCommands() {
 		result += fmt.Sprintf("\n                _%v_callback '_'", cmd.Root().Name())
 	}
 	result += fmt.Sprint("\n            }")

--- a/uid/uid.go
+++ b/uid/uid.go
@@ -3,6 +3,8 @@ package uid
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -56,4 +58,14 @@ func find(cmd *cobra.Command, uid string) *cobra.Command {
 		log.Fatal(err)
 	}
 	return c
+}
+
+func Executable() string {
+	if executable, err := os.Executable(); err != nil {
+		return "echo" // safe fallback that should never happen
+	} else if filepath.Base(executable) == "cmd.test" {
+		return "example" // for `go test -v ./...`
+	} else {
+		return filepath.Base(executable)
+	}
 }

--- a/zsh/action.go
+++ b/zsh/action.go
@@ -2,6 +2,7 @@ package zsh
 
 import (
 	"fmt"
+	"github.com/rsteube/carapace/uid"
 	"strings"
 )
 
@@ -29,8 +30,8 @@ func Sanitize(values ...string) []string {
 	return sanitized
 }
 
-func Callback(uid string) string {
-	return ActionExecute(fmt.Sprintf(`${os_args[1]} _carapace zsh '%v' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"}`, uid))
+func Callback(cuid string) string {
+	return ActionExecute(fmt.Sprintf(`%v _carapace zsh '%v' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"}`, uid.Executable(), cuid))
 }
 
 // ActionExecute uses command substitution to invoke a command and evalues it's result as Action

--- a/zsh/snippet.go
+++ b/zsh/snippet.go
@@ -32,7 +32,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 `
 
 	commandsVar := ""
-	if cmd.HasSubCommands() {
+	if cmd.HasAvailableSubCommands() {
 		commandsVar = "local -a commands\n"
 	}
 
@@ -56,7 +56,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 	})
 
 	positionals := make([]string, 0)
-	if cmd.HasSubCommands() {
+	if cmd.HasAvailableSubCommands() {
 		positionals = []string{`    "1: :->cmnds"`, `    "*::arg:->args"`}
 	} else {
 		pos := 1
@@ -124,7 +124,7 @@ func zshCompFlagCouldBeSpecifiedMoreThenOnce(f *pflag.Flag) bool {
 }
 
 func snippetSubcommands(cmd *cobra.Command) string {
-	if !cmd.HasSubCommands() {
+	if !cmd.HasAvailableSubCommands() {
 		return ""
 	}
 	cmnds := make([]string, 0)

--- a/zsh/snippet_test.go
+++ b/zsh/snippet_test.go
@@ -39,17 +39,21 @@ func TestSnippetPositionalCompletion(t *testing.T) {
 func TestSnippetSubcommands(t *testing.T) {
 	root := &cobra.Command{
 		Use: "root",
+		Run: func(cmd *cobra.Command, args []string) {},
 	}
 	sub1 := &cobra.Command{
 		Use:     "sub1",
+		Run:     func(cmd *cobra.Command, args []string) {},
 		Aliases: []string{"alias1", "alias2"},
 	}
 	sub2 := &cobra.Command{
 		Use:   "sub2",
+		Run:   func(cmd *cobra.Command, args []string) {},
 		Short: "short description",
 	}
 	hidden := &cobra.Command{
 		Use:    "hidden",
+		Run:    func(cmd *cobra.Command, args []string) {},
 		Hidden: true,
 	}
 	root.AddCommand(sub1)


### PR DESCRIPTION
completions for root cmd name and callbacks are directed to the carapace
binary