### PR TITLE
updated ActionMultiParts

### DIFF
--- a/Dockerfile.elvish
+++ b/Dockerfile.elvish
@@ -1,6 +1,6 @@
 FROM golang
 
-RUN curl https://dl.elv.sh/linux-amd64/elvish-v0.13.1.tar.gz | tar -xvz \
+RUN curl https://dl.elv.sh/linux-amd64/elvish-HEAD.tar.gz | tar -xvz \
  && mv elvish-* /usr/local/bin/elvish
 
 ENV PS1=$'%{\e[0;36m%}carapace %{\e[0m%}'

--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ Since callbacks are simply invocations of the program they can be tested directl
 # _message -r 'flag --required must be set to valid: invalid'
 ```
 
+### ActionMultiParts
+
+> This is an initial version which still got some quirks, expect some changes here
+
+ActionMultiParts is a [callback action](#actioncallback) where parts of an argument can be completed separately (e.g. user:group from [chown](https://github.com/rsteube/carapace-completers/blob/master/completers/chown_completer/cmd/root.go)). Divider can be empty as well, but note that `bash` and `fish` will add the space suffix for anything other than `/=@:.,` (it still works, but after each selction backspace is needed to continue the completion).
+
+```go
+carapace.ActionMultiParts(":", func(args []string, parts []string) []string {
+	switch len(parts) {
+	case 0:
+		return []{"user1:", "user2:", "user3:"}
+	case 1:
+		return []{"groupA", "groupB", "groupC"}
+	default:
+		return []string{}
+	}
+})
+```
+
 ### Custom Action
 
 For [actions](#action) that aren't implemented or missing required options, a custom action can be defined.

--- a/bash/action.go
+++ b/bash/action.go
@@ -91,6 +91,21 @@ func ActionMessage(msg string) string {
 	return ActionValues("ERR", Sanitize(msg)[0])
 }
 
-func ActionMultiParts(separator rune, values ...string) string {
-	return ActionValues(values...)
+func ActionPrefixValues(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		// TODO escape special characters
+		vals[index] = strings.Replace(val, ` `, `\\\ `, -1)
+	}
+
+	if index := strings.LastIndexAny(prefix, ":="); index > -1 {
+		// COMP_WORD will split on these characters, so $last does not contain the full argument
+		prefix = prefix[index:]
+	}
+	return fmt.Sprintf(`compgen -W $'%v' -- "${last/%v/}"`, strings.Join(vals, `\n`), prefix)
 }

--- a/bash/snippet.go
+++ b/bash/snippet.go
@@ -19,7 +19,7 @@ _%v_callback() {
       last="${last// /\\\\ }" 
   fi
 
-  echo "$compline" | sed -e 's/ $/ _/' -e 's/"/\"/g' | xargs %v _carapace bash "$1"
+  echo "$compline" | sed -e "s/ $/ ''/" -e 's/"/\"/g' | xargs %v _carapace bash "$1"
 }
 
 _%v_completions() {
@@ -34,7 +34,7 @@ _%v_completions() {
   fi
 
   local state
-  state="$(echo "$compline" | sed -e "s/ \$/ _/" -e 's/"/\"/g' | xargs %v _carapace bash state)"
+  state="$(echo "$compline" | sed -e "s/ \$/ ''/" -e 's/"/\"/g' | xargs %v _carapace bash state)"
   local previous="${COMP_WORDS[$((COMP_CWORD-1))]}"
   local IFS=$'\n'
 
@@ -43,7 +43,7 @@ _%v_completions() {
   esac
 
   [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
-  [[ ${COMPREPLY[0]} == */ ]] && compopt -o nospace
+  [[ ${COMPREPLY[0]} == *[/=@:.,] ]] && compopt -o nospace
 }
 
 complete -F _%v_completions %v

--- a/elvish/action.go
+++ b/elvish/action.go
@@ -53,10 +53,6 @@ func ActionUsers() string {
 	return `` // TODO
 }
 
-func ActionGroups() string {
-	return `` // TODO
-}
-
 func ActionHosts() string {
 	return `` // TODO
 }
@@ -92,6 +88,16 @@ func ActionMessage(msg string) string {
 	return ActionValuesDescribed("ERR", Sanitize(msg)[0], "_", "")
 }
 
-func ActionMultiParts(separator rune, values ...string) string {
-	return ActionValues(values...)
+func ActionPrefixValues(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		// TODO escape special characters
+		vals[index] = fmt.Sprintf(`edit:complex-candidate '%v' &display='%v'`, prefix+val, val)
+	}
+	return strings.Join(vals, "\n")
 }

--- a/example/cmd/action.go
+++ b/example/cmd/action.go
@@ -24,7 +24,6 @@ func init() {
 	actionCmd.Flags().StringP("values", "v", "", "values flag")
 	actionCmd.Flags().StringP("values_described", "d", "", "values with description flag")
 	actionCmd.Flags().StringP("custom", "c", "", "custom flag")
-	actionCmd.Flags().String("multi_parts", "", "multi_parts flag")
 
 	carapace.Gen(actionCmd).FlagCompletion(carapace.ActionMap{
 		"files":            carapace.ActionFiles(".go"),
@@ -37,7 +36,6 @@ func init() {
 		"values":           carapace.ActionValues("values", "example"),
 		"values_described": carapace.ActionValuesDescribed("values", "valueDescription", "example", "exampleDescription"),
 		"custom":           carapace.Action{Zsh: "_most_recent_file 2"},
-		"multi_parts":      carapace.ActionMultiParts('/', "multi/parts", "multi/parts/example", "multi/parts/test", "example/parts"),
 	})
 
 	carapace.Gen(actionCmd).PositionalCompletion(

--- a/example/cmd/callback.go
+++ b/example/cmd/callback.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,23 @@ func init() {
 	carapace.Gen(callbackCmd).PositionalCompletion(
 		carapace.ActionCallback(func(args []string) carapace.Action {
 			return carapace.ActionValues("callback1", "callback2")
+		}),
+		carapace.ActionMultiParts("=", func(args []string, parts []string) []string {
+			switch len(parts) {
+			case 0:
+				return []string{"alpha=", "beta=", "gamma"}
+			case 1:
+				switch parts[0] {
+				case "alpha":
+					return []string{"one", "two", "three"}
+				case "beta":
+					return []string{"1", "2", "3"}
+				default:
+					return []string{}
+				}
+			default:
+				return []string{}
+			}
 		}),
 	)
 

--- a/example/cmd/root_test.go
+++ b/example/cmd/root_test.go
@@ -17,7 +17,7 @@ _example_callback() {
       last="${last// /\\\\ }" 
   fi
 
-  echo "$compline" | sed -e 's/ $/ _/' -e 's/"/\"/g' | xargs example _carapace bash "$1"
+  echo "$compline" | sed -e "s/ $/ ''/" -e 's/"/\"/g' | xargs example _carapace bash "$1"
 }
 
 _example_completions() {
@@ -32,7 +32,7 @@ _example_completions() {
   fi
 
   local state
-  state="$(echo "$compline" | sed -e "s/ \$/ _/" -e 's/"/\"/g' | xargs example _carapace bash state)"
+  state="$(echo "$compline" | sed -e "s/ \$/ ''/" -e 's/"/\"/g' | xargs example _carapace bash state)"
   local previous="${COMP_WORDS[$((COMP_CWORD-1))]}"
   local IFS=$'\n'
 
@@ -59,7 +59,7 @@ _example_completions() {
 
     '_example__action' )
       if [[ $last == -* ]]; then
-        COMPREPLY=($(compgen -W $'--custom\n-c\n--directories\n--files\n-f\n--groups\n-g\n--hosts\n--message\n-m\n--multi_parts\n--net_interfaces\n-n\n--users\n-u\n--values\n-v\n--values_described\n-d' -- "$last"))
+        COMPREPLY=($(compgen -W $'--custom\n-c\n--directories\n--files\n-f\n--groups\n-g\n--hosts\n--message\n-m\n--net_interfaces\n-n\n--users\n-u\n--values\n-v\n--values_described\n-d' -- "$last"))
       else
         case $previous in
           -c | --custom)
@@ -84,10 +84,6 @@ _example_completions() {
 
           -m | --message)
             COMPREPLY=($(compgen -W $'ERR\nmessage\\\ example' -- "$last"))
-            ;;
-
-          --multi_parts)
-            COMPREPLY=($(compgen -W $'multi/parts\nmulti/parts/example\nmulti/parts/test\nexample/parts' -- "$last"))
             ;;
 
           -n | --net_interfaces)
@@ -178,7 +174,7 @@ _example_completions() {
   esac
 
   [[ $last =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
-  [[ ${COMPREPLY[0]} == */ ]] && compopt -o nospace
+  [[ ${COMPREPLY[0]} == *[/=@:.,] ]] && compopt -o nospace
 }
 
 complete -F _example_completions example
@@ -235,15 +231,14 @@ edit:complex-candidate injection &display-suffix=' (just trying to break things)
         [&long='custom' &desc='custom flag' &short='c' &arg-required=$true &completer=[_]{  }]
         [&long='directories' &desc='files flag' &arg-required=$true &completer=[_]{ edit:complete-filename $arg[-1] }]
         [&long='files' &desc='files flag' &short='f' &arg-required=$true &completer=[_]{ edit:complete-filename $arg[-1] }]
-        [&long='groups' &desc='groups flag' &short='g' &arg-required=$true &completer=[_]{  }]
-        [&long='hosts' &desc='hosts flag' &arg-required=$true &completer=[_]{  }]
+        [&long='groups' &desc='groups flag' &short='g' &arg-required=$true &completer=[_]{ _example_callback '_example__action##groups' }]
+        [&long='hosts' &desc='hosts flag' &arg-required=$true &completer=[_]{ _example_callback '_example__action##hosts' }]
         [&long='message' &desc='message flag' &short='m' &arg-required=$true &completer=[_]{ edit:complex-candidate ERR &display-suffix=' (message example)'
 edit:complex-candidate _ &display-suffix=' ()'
 
  }]
-        [&long='multi_parts' &desc='multi_parts flag' &arg-required=$true &completer=[_]{ put multi/parts multi/parts/example multi/parts/test example/parts }]
         [&long='net_interfaces' &desc='net_interfaces flag' &short='n' &arg-required=$true &completer=[_]{  }]
-        [&long='users' &desc='users flag' &short='u' &arg-required=$true &completer=[_]{  }]
+        [&long='users' &desc='users flag' &short='u' &arg-required=$true &completer=[_]{ _example_callback '_example__action##users' }]
         [&long='values' &desc='values flag' &short='v' &arg-required=$true &completer=[_]{ put values example }]
         [&long='values_described' &desc='values with description flag' &short='d' &arg-required=$true &completer=[_]{ edit:complex-candidate values &display-suffix=' (valueDescription)'
 edit:complex-candidate example &display-suffix=' (exampleDescription)'
@@ -264,6 +259,7 @@ edit:complex-candidate example &display-suffix=' (exampleDescription)'
     ]
     arg-handlers = [
       [_]{ _example_callback '_example__callback#1' }
+      [_]{ _example_callback '_example__callback#2' }
       [_]{ _example_callback '_example__callback#0' }
       ...
     ]
@@ -346,48 +342,47 @@ function _example_state
 end
 
 function _example_callback
-  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_example_quote_suffix)"/" | sed "s/ \$/ _/" | xargs example _carapace fish $argv )
+  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_example_quote_suffix)"/" | sed "s/ \$/ ''/" | xargs example _carapace fish $argv )
   eval "$CALLBACK"
 end
 
 complete -c example -f
 
-complete -c example -f -n '_example_state _example' -l array -s a -d 'multiflag' -r
-complete -c example -f -n '_example_state _example' -l persistentFlag -s p -d 'Help message for persistentFlag'
-complete -c example -f -n '_example_state _example' -l toggle -s t -d 'Help message for toggle' -a '(echo -e "true\nfalse")' -r
-complete -c example -f -n '_example_state _example ' -a 'action alias' -d 'action example'
-complete -c example -f -n '_example_state _example ' -a 'callback ' -d 'callback example'
-complete -c example -f -n '_example_state _example ' -a 'condition ' -d 'condition example'
-complete -c example -f -n '_example_state _example ' -a 'help ' -d 'Help about any command'
-complete -c example -f -n '_example_state _example ' -a 'injection ' -d 'just trying to break things'
+complete -c 'example' -f -n '_example_state _example' -l 'array' -s 'a' -d 'multiflag' -r
+complete -c 'example' -f -n '_example_state _example' -l 'persistentFlag' -s 'p' -d 'Help message for persistentFlag'
+complete -c 'example' -f -n '_example_state _example' -l 'toggle' -s 't' -d 'Help message for toggle' -a '(echo -e "true\nfalse")' -r
+complete -c 'example' -f -n '_example_state _example ' -a 'action alias' -d 'action example'
+complete -c 'example' -f -n '_example_state _example ' -a 'callback ' -d 'callback example'
+complete -c 'example' -f -n '_example_state _example ' -a 'condition ' -d 'condition example'
+complete -c 'example' -f -n '_example_state _example ' -a 'help ' -d 'Help about any command'
+complete -c 'example' -f -n '_example_state _example ' -a 'injection ' -d 'just trying to break things'
 
 
-complete -c example -f -n '_example_state _example__action' -l custom -s c -d 'custom flag' -a '()' -r
-complete -c example -f -n '_example_state _example__action' -l directories -d 'files flag' -a '(__fish_complete_directories)' -r
-complete -c example -f -n '_example_state _example__action' -l files -s f -d 'files flag' -a '(__fish_complete_suffix ".go")' -r
-complete -c example -f -n '_example_state _example__action' -l groups -s g -d 'groups flag' -a '(__fish_complete_groups)' -r
-complete -c example -f -n '_example_state _example__action' -l hosts -d 'hosts flag' -a '(__fish_print_hostnames)' -r
-complete -c example -f -n '_example_state _example__action' -l message -s m -d 'message flag' -a '(echo -e "ERR\tmessage example\n_")' -r
-complete -c example -f -n '_example_state _example__action' -l multi_parts -d 'multi_parts flag' -a '(echo -e "multi/parts\nmulti/parts/example\nmulti/parts/test\nexample/parts")' -r
-complete -c example -f -n '_example_state _example__action' -l net_interfaces -s n -d 'net_interfaces flag' -a '(__fish_print_interfaces)' -r
-complete -c example -f -n '_example_state _example__action' -l users -s u -d 'users flag' -a '(__fish_complete_users)' -r
-complete -c example -f -n '_example_state _example__action' -l values -s v -d 'values flag' -a '(echo -e "values\nexample")' -r
-complete -c example -f -n '_example_state _example__action' -l values_described -s d -d 'values with description flag' -a '(echo -e "values\tvalueDescription\nexample\texampleDescription\n\n")' -r
-complete -c example -f -n '_example_state _example__action' -a '(_example_callback _)'
+complete -c 'example' -f -n '_example_state _example__action' -l 'custom' -s 'c' -d 'custom flag' -a '()' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'directories' -d 'files flag' -a '(__fish_complete_directories)' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'files' -s 'f' -d 'files flag' -a '(__fish_complete_suffix ".go")' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'groups' -s 'g' -d 'groups flag' -a '(__fish_complete_groups)' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'hosts' -d 'hosts flag' -a '(__fish_print_hostnames)' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'message' -s 'm' -d 'message flag' -a '(echo -e "ERR\tmessage example\n_")' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'net_interfaces' -s 'n' -d 'net_interfaces flag' -a '(__fish_print_interfaces)' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'users' -s 'u' -d 'users flag' -a '(__fish_complete_users)' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'values' -s 'v' -d 'values flag' -a '(echo -e "values\nexample")' -r
+complete -c 'example' -f -n '_example_state _example__action' -l 'values_described' -s 'd' -d 'values with description flag' -a '(echo -e "values\tvalueDescription\nexample\texampleDescription\n\n")' -r
+complete -c 'example' -f -n '_example_state _example__action' -a '(_example_callback _)'
 
 
-complete -c example -f -n '_example_state _example__callback' -l callback -s c -d 'Help message for callback' -a '(_example_callback _example__callback##callback)' -r
-complete -c example -f -n '_example_state _example__callback' -a '(_example_callback _)'
+complete -c 'example' -f -n '_example_state _example__callback' -l 'callback' -s 'c' -d 'Help message for callback' -a '(_example_callback _example__callback##callback)' -r
+complete -c 'example' -f -n '_example_state _example__callback' -a '(_example_callback _)'
 
 
-complete -c example -f -n '_example_state _example__condition' -l required -s r -d 'required flag' -a '(echo -e "valid\ninvalid")' -r
-complete -c example -f -n '_example_state _example__condition' -a '(_example_callback _)'
+complete -c 'example' -f -n '_example_state _example__condition' -l 'required' -s 'r' -d 'required flag' -a '(echo -e "valid\ninvalid")' -r
+complete -c 'example' -f -n '_example_state _example__condition' -a '(_example_callback _)'
 
 
-complete -c example -f -n '_example_state _example__help' -a '(_example_callback _)'
+complete -c 'example' -f -n '_example_state _example__help' -a '(_example_callback _)'
 
 
-complete -c example -f -n '_example_state _example__injection' -a '(_example_callback _)'
+complete -c 'example' -f -n '_example_state _example__injection' -a '(_example_callback _)'
 `
 	rootCmd.InitDefaultHelpCmd()
 	assert.Equal(t, expected, carapace.Gen(rootCmd).Fish())
@@ -409,7 +404,7 @@ Register-ArgumentCompleter -Native -CommandName 'example' -ScriptBlock {
     Function _example_callback {
       param($uid)
       if (!$wordToComplete) {
-        example _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) _ | Out-String | Invoke-Expression
+        example _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) "''" | Out-String | Invoke-Expression
       } else {
         example _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) | Out-String | Invoke-Expression
       }
@@ -458,11 +453,11 @@ Register-ArgumentCompleter -Native -CommandName 'example' -ScriptBlock {
                         break
                       }
                 '^(-g|--groups)$' {
-                        $(Get-Localgroup).Name 
+                        _example_callback '_example__action##groups' 
                         break
                       }
                 '^(--hosts)$' {
-                         
+                        _example_callback '_example__action##hosts' 
                         break
                       }
                 '^(-m|--message)$' {
@@ -472,19 +467,12 @@ Register-ArgumentCompleter -Native -CommandName 'example' -ScriptBlock {
                          
                         break
                       }
-                '^(--multi_parts)$' {
-                        [CompletionResult]::new('multi/parts ', 'multi/parts', [CompletionResultType]::ParameterValue, ' ')
-                        [CompletionResult]::new('multi/parts/example ', 'multi/parts/example', [CompletionResultType]::ParameterValue, ' ')
-                        [CompletionResult]::new('multi/parts/test ', 'multi/parts/test', [CompletionResultType]::ParameterValue, ' ')
-                        [CompletionResult]::new('example/parts ', 'example/parts', [CompletionResultType]::ParameterValue, ' ') 
-                        break
-                      }
                 '^(-n|--net_interfaces)$' {
                         $(Get-NetAdapter).Name 
                         break
                       }
                 '^(-u|--users)$' {
-                        $(Get-LocalUser).Name 
+                        _example_callback '_example__action##users' 
                         break
                       }
                 '^(-v|--values)$' {
@@ -512,7 +500,6 @@ Register-ArgumentCompleter -Native -CommandName 'example' -ScriptBlock {
                 [CompletionResult]::new('--hosts ', '--hosts', [CompletionResultType]::ParameterName, 'hosts flag')
                 [CompletionResult]::new('-m ', '-m', [CompletionResultType]::ParameterName, 'message flag')
                 [CompletionResult]::new('--message ', '--message', [CompletionResultType]::ParameterName, 'message flag')
-                [CompletionResult]::new('--multi_parts ', '--multi_parts', [CompletionResultType]::ParameterName, 'multi_parts flag')
                 [CompletionResult]::new('-n ', '-n', [CompletionResultType]::ParameterName, 'net_interfaces flag')
                 [CompletionResult]::new('--net_interfaces ', '--net_interfaces', [CompletionResultType]::ParameterName, 'net_interfaces flag')
                 [CompletionResult]::new('-u ', '-u', [CompletionResultType]::ParameterName, 'users flag')
@@ -669,7 +656,6 @@ function _example__action {
     "(-g --groups)"{-g,--groups}"[groups flag]: :_groups" \
     "--hosts[hosts flag]: :_hosts" \
     "(-m --message)"{-m,--message}"[message flag]: : _message -r 'message example'" \
-    "--multi_parts[multi_parts flag]: :_multi_parts / '(multi/parts multi/parts/example multi/parts/test example/parts)'" \
     "(-n --net_interfaces)"{-n,--net_interfaces}"[net_interfaces flag]: :_net_interfaces" \
     "(-u --users)"{-u,--users}"[users flag]: :_users" \
     "(-v --values)"{-v,--values}"[values flag]: :_values '' values example" \
@@ -682,6 +668,7 @@ function _example__callback {
     _arguments -C \
     "(-c --callback)"{-c,--callback}"[Help message for callback]: : eval \$(example _carapace zsh '_example__callback##callback' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})" \
     "1: : eval \$(example _carapace zsh '_example__callback#1' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})" \
+    "2: : eval \$(example _carapace zsh '_example__callback#2' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})" \
     "*: : eval \$(example _carapace zsh '_example__callback#0' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})"
 }
 

--- a/fish/action.go
+++ b/fish/action.go
@@ -85,6 +85,17 @@ func ActionMessage(msg string) string {
 	return ActionExecute(fmt.Sprintf(`echo -e "ERR\t%v\n_"`, Sanitize(msg)[0]))
 }
 
-func ActionMultiParts(separator rune, values ...string) string {
-	return ActionValues(values...)
+func ActionPrefixValues(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		// TODO escape special characters
+		//vals[index] = strings.Replace(val, " ", `\ `, -1)
+		vals[index] = prefix + val
+	}
+	return ActionExecute(fmt.Sprintf(`echo -e "%v"`, strings.Join(vals, `\n`)))
 }

--- a/fish/snippet.go
+++ b/fish/snippet.go
@@ -41,7 +41,7 @@ function _%v_state
 end
 
 function _%v_callback
-  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_%v_quote_suffix)"/" | sed "s/ \$/ _/" | xargs %v _carapace fish $argv )
+  set -lx CALLBACK (commandline -cp | sed "s/\$/"(_%v_quote_suffix)"/" | sed "s/ \$/ ''/" | xargs %v _carapace fish $argv )
   eval "$CALLBACK"
 end
 
@@ -76,7 +76,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 		positionals = []string{}
 		for _, subcmd := range cmd.Commands() {
 			if !subcmd.Hidden {
-				positionals = append(positionals, fmt.Sprintf(`complete -c %v -f -n '_%v_state %v ' -a '%v' -d '%v'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), subcmd.Name()+" "+strings.Join(subcmd.Aliases, " "), replacer.Replace(subcmd.Short)))
+				positionals = append(positionals, fmt.Sprintf(`complete -c '%v' -f -n '_%v_state %v ' -a '%v' -d '%v'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), subcmd.Name()+" "+strings.Join(subcmd.Aliases, " "), replacer.Replace(subcmd.Short)))
 			}
 		}
 	} else {
@@ -84,7 +84,7 @@ func snippetFunctions(cmd *cobra.Command, actions map[string]string) string {
 			if cmd.ValidArgs != nil {
 				//positionals = []string{"    " + snippetPositionalCompletion(1, ActionValues(cmd.ValidArgs...))}
 			}
-			positionals = append(positionals, fmt.Sprintf(`complete -c %v -f -n '_%v_state %v' -a '(_%v_callback _)'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), cmd.Root().Name()))
+			positionals = append(positionals, fmt.Sprintf(`complete -c '%v' -f -n '_%v_state %v' -a '(_%v_callback _)'`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), cmd.Root().Name()))
 		}
 	}
 
@@ -113,9 +113,9 @@ func snippetFlagCompletion(cmd *cobra.Command, flag *pflag.Flag, action *string)
 	}
 
 	if flag.Shorthand == "" { // no shorthannd
-		snippet = fmt.Sprintf(`complete -c %v -f -n '_%v_state %v' -l %v -d '%v'%v`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), flag.Name, replacer.Replace(flag.Usage), suffix)
+		snippet = fmt.Sprintf(`complete -c '%v' -f -n '_%v_state %v' -l '%v' -d '%v'%v`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), flag.Name, replacer.Replace(flag.Usage), suffix)
 	} else {
-		snippet = fmt.Sprintf(`complete -c %v -f -n '_%v_state %v' -l %v -s %v -d '%v'%v`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), flag.Name, flag.Shorthand, replacer.Replace(flag.Usage), suffix)
+		snippet = fmt.Sprintf(`complete -c '%v' -f -n '_%v_state %v' -l '%v' -s '%v' -d '%v'%v`, cmd.Root().Name(), cmd.Root().Name(), uid.Command(cmd), flag.Name, flag.Shorthand, replacer.Replace(flag.Usage), suffix)
 	}
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/alecthomas/chroma v0.7.1
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=

--- a/powershell/action.go
+++ b/powershell/action.go
@@ -94,6 +94,15 @@ func ActionMessage(msg string) string {
 	return ActionValuesDescribed("_", msg, "ERR", msg)
 }
 
-func ActionMultiParts(separator rune, values ...string) string {
-	return ActionValues(values...)
+func ActionPrefixValues(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		vals[index] = fmt.Sprintf(`[CompletionResult]::new('%v', '%v', [CompletionResultType]::ParameterValue, ' ')`, EscapeSpace(prefix+val), val)
+	}
+	return strings.Join(vals, "\n")
 }

--- a/powershell/snippet.go
+++ b/powershell/snippet.go
@@ -36,7 +36,7 @@ Register-ArgumentCompleter -Native -CommandName '%s' -ScriptBlock {
     Function _%v_callback {
       param($uid)
       if (!$wordToComplete) {
-        %v _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) _ | Out-String | Invoke-Expression
+        %v _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) "''" | Out-String | Invoke-Expression
       } else {
         %v _carapace powershell "$uid" $($commandElements| Foreach {$_.Extent}) | Out-String | Invoke-Expression
       }

--- a/uid/uid.go
+++ b/uid/uid.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -46,6 +47,26 @@ func Flag(cmd *cobra.Command, flag *pflag.Flag) string {
 func Positional(cmd *cobra.Command, position int) string {
 	// TODO complete function
 	return fmt.Sprintf("%v#%v", Command(cmd), position)
+}
+
+func Value(cmd *cobra.Command, args []string, uid string) string {
+	// TODO assumes cmd is correct
+	if strings.Contains(uid, "##") {
+		split := strings.Split(uid, "##")
+		if flag := cmd.Flag(split[len(split)-1]); flag != nil {
+			return flag.Value.String()
+		}
+
+	} else if strings.Contains(uid, "#") {
+		split := strings.Split(uid, "#")
+		if index, err := strconv.Atoi(split[len(split)-1]); err == nil {
+			index = index - 1
+			if len(args)-1 >= index && index >= 0 {
+				return args[index]
+			}
+		}
+	}
+	return ""
 }
 
 func find(cmd *cobra.Command, uid string) *cobra.Command {

--- a/zsh/action.go
+++ b/zsh/action.go
@@ -112,7 +112,35 @@ func ActionMessage(msg string) string {
 	return fmt.Sprintf(" _message -r '%v'", msg) // space before _message is necessary
 }
 
-// ActionMultiParts completes multiple parts of words separately where each part is separated by some char
-func ActionMultiParts(separator rune, values ...string) string {
-	return fmt.Sprintf("_multi_parts %v '(%v)'", string(separator), strings.Join(values, " "))
+func ActionPrefixValues(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		// TODO escape special characters
+		//vals[index] = fmt.Sprintf("'%v'" ,strings.Replace(val, " ", `\ `, -1))
+		vals[index] = fmt.Sprintf("'%v'", val)
+	}
+	//return fmt.Sprintf("compadd -S '' -P '%v' %v", currentValue, strings.Join(vals, " "))
+	return fmt.Sprintf("compadd -S '' -p '%v' %v", prefix, strings.Join(vals, " "))
+}
+
+func ActionPrefixValuesDescribed(prefix string, values ...string) string {
+	sanitized := Sanitize(values...)
+	if len(strings.TrimSpace(strings.Join(sanitized, ""))) == 0 {
+		return ActionMessage("no values to complete")
+	}
+
+	vals := make([]string, len(sanitized))
+	for index, val := range sanitized {
+		// TODO escape special characters
+		//vals[index] = fmt.Sprintf("'%v'" ,strings.Replace(val, " ", `\ `, -1))
+		vals[index] = fmt.Sprintf("'%v'", val)
+	}
+	//return fmt.Sprintf("compadd -S '' -P '%v' %v", currentValue, strings.Join(vals, " "))
+	// TODO
+	return fmt.Sprintf("local _comp_desc(desc1 desc2 desc3);compadd -S '' -l -d _comp_desc -p '%v' %v", prefix, strings.Join(vals, " "))
 }


### PR DESCRIPTION
ActionMultiParts is now a callback action and works for all shells

- updated elvish to HEAD version (docker)
- added NestedValue for callback actions returned during callback
(callback function must be executed for actual values)
- added callback for ActionUsers, ActionGroups and ActionHosts (to
support all shells - currently only for linux)
- added ActionPrefixValues (WIP: needed for ActionMultiParts)
- added carapace.CallbackValue whose content is set to currently completed
argument during callback
- replaced '-' with "''" as position indicator during callback (scripts)
- bash compopt nospace now set for `/=@:.,` suffixes (same as in latest
fish version)
- updated traverse for position indicator change
- added missing quotation for fish