### PR TITLE
powershell: fix `’` (breaks completion)

### DIFF
--- a/powershell/action.go
+++ b/powershell/action.go
@@ -22,6 +22,7 @@ var sanitizer = strings.NewReplacer( // TODO
 	`)`, ``,
 	`;`, ``,
 	`#`, ``,
+	`’`, ``,
 )
 
 func Sanitize(values ...string) []string {


### PR DESCRIPTION
fixes #112 