### PR TITLE
bash: fix prefix removal

### DIFF
--- a/example/cmd/root_test.go
+++ b/example/cmd/root_test.go
@@ -267,6 +267,7 @@ _example_completions() {
 
   [[ $cur =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
   [[ ${#COMPREPLY[*]} -gt 1 ]] && COMPREPLY=("${COMPREPLY[@]#*	}") # show visual part (all after tab)
+  [[ ${#COMPREPLY[*]} -gt 1 ]] && [[ "$(printf  "%c\n" "${COMPREPLY[@]}" | uniq | wc -l)" -eq 1 ]] && COMPREPLY=("${COMPREPLY[@]}" "_ (ignore me)") # prevent insertion if all have same first character (workaround for #164)
   [[ ${#COMPREPLY[*]} -eq 1 ]] && COMPREPLY=( ${COMPREPLY[0]%	*} ) # show value to insert (all before tab) https://stackoverflow.com/a/10130007
   [[ ${COMPREPLY[0]} == *[/=@:.,] ]] && compopt -o nospace
 }

--- a/internal/bash/snippet.go
+++ b/internal/bash/snippet.go
@@ -63,6 +63,7 @@ _%v_completions() {
 
   [[ $cur =~ ^[\"\'] ]] && COMPREPLY=("${COMPREPLY[@]//\\ /\ }")
   [[ ${#COMPREPLY[*]} -gt 1 ]] && COMPREPLY=("${COMPREPLY[@]#*	}") # show visual part (all after tab)
+  [[ ${#COMPREPLY[*]} -gt 1 ]] && [[ "$(printf  "%%c\n" "${COMPREPLY[@]}" | uniq | wc -l)" -eq 1 ]] && COMPREPLY=("${COMPREPLY[@]}" "_ (ignore me)") # prevent insertion if all have same first character (workaround for #164)
   [[ ${#COMPREPLY[*]} -eq 1 ]] && COMPREPLY=( ${COMPREPLY[0]%%	*} ) # show value to insert (all before tab) https://stackoverflow.com/a/10130007
   [[ ${COMPREPLY[0]} == *[/=@:.,] ]] && compopt -o nospace
 }


### PR DESCRIPTION
fixes #164 

Although multiple values are provided bash might insert part of it if the all have the same prefix.
But this would skip/remove the prefix of an ActionMultiParts as this are the display values and not what is intended to be inserted into the line.
To prevent this a dummy value (`_`) is added.