### PR TITLE
zsh: mimic standard completion style

### DIFF
--- a/example/cmd/_test/zsh.sh
+++ b/example/cmd/_test/zsh.sh
@@ -24,7 +24,7 @@ function _example_completion {
   # shellcheck disable=SC2034,2206
   vals=(${vals%%$'\001'*})
 
-  compadd -S "${suffix}" -d descriptions -a -- vals
+  compadd -l -S "${suffix}" -d descriptions -a -- vals
 }
 compquote '' 2>/dev/null && _example_completion
 compdef _example_completion example

--- a/internal/zsh/action.go
+++ b/internal/zsh/action.go
@@ -18,9 +18,13 @@ var sanitizer = strings.NewReplacer(
 func ActionRawValues(currentWord string, nospace bool, values ...common.RawValue) string {
 	filtered := make([]common.RawValue, 0)
 
+	maxLength := 0
 	for _, r := range values {
 		if strings.HasPrefix(r.Value, currentWord) {
 			filtered = append(filtered, r)
+			if length := len(r.Display); length > maxLength {
+				maxLength = length
+			}
 		}
 	}
 
@@ -36,7 +40,7 @@ func ActionRawValues(currentWord string, nospace bool, values ...common.RawValue
 		if strings.TrimSpace(val.Description) == "" {
 			vals[index] = fmt.Sprintf("%v\t%v", val.Value, val.Display)
 		} else {
-			vals[index] = fmt.Sprintf("%v\t%v (%v)", val.Value, val.Display, val.TrimmedDescription())
+			vals[index] = fmt.Sprintf("%v\t%v %v-- %v", val.Value, val.Display, strings.Repeat(" ", maxLength-len(val.Display)), val.TrimmedDescription())
 		}
 	}
 	return strings.Join(vals, "\n")

--- a/internal/zsh/snippet.go
+++ b/internal/zsh/snippet.go
@@ -35,7 +35,7 @@ function _%v_completion {
   # shellcheck disable=SC2034,2206
   vals=(${vals%%%%$'\001'*})
 
-  compadd -S "${suffix}" -d descriptions -a -- vals
+  compadd -l -S "${suffix}" -d descriptions -a -- vals
 }
 compquote '' 2>/dev/null && _%v_completion
 compdef _%v_completion %v


### PR DESCRIPTION
Mimic standard completion style by only showing one per line with an alligned `--` delimiter
related #rsteube/carapace-bin#417