### PR TITLE
fix traverse

### DIFF
--- a/internal/common/traverse.go
+++ b/internal/common/traverse.go
@@ -34,7 +34,9 @@ func TraverseLenient(cmd *cobra.Command, args []string) (*cobra.Command, []strin
 		if len(args) > 0 &&
 			name == args[len(args)-1] &&
 			len(targetCmd.Flags().Args()) == 0 {
-			targetCmd = targetCmd.Parent() // when argument currently being completed is fully matching a subcommand it will be returned, so fix this to parent
+			if targetCmd.HasParent() {
+				targetCmd = targetCmd.Parent() // when argument currently being completed is fully matching a subcommand it will be returned, so fix this to parent
+			}
 		}
 	}
 	return targetCmd, targetCmd.Flags().Args(), filterError(args, err)


### PR DESCRIPTION
```sh
carapace --style carapace<TAB>
```
Caused an error because the commands name fully matched but was the root
command (parentCmd == nil).
