### PR TITLE
Code refactoring (main functions)

### DIFF
--- a/carapace.go
+++ b/carapace.go
@@ -7,12 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sort"
-	"strings"
 
-	"github.com/rsteube/carapace/internal/common"
-	"github.com/rsteube/carapace/internal/config"
-	"github.com/rsteube/carapace/internal/pflagfork"
 	"github.com/rsteube/carapace/internal/shell/bash"
 	"github.com/rsteube/carapace/internal/shell/bash_ble"
 	"github.com/rsteube/carapace/internal/shell/elvish"
@@ -22,23 +17,21 @@ import (
 	"github.com/rsteube/carapace/internal/shell/nushell"
 	"github.com/rsteube/carapace/internal/shell/oil"
 	"github.com/rsteube/carapace/internal/shell/powershell"
-	"github.com/rsteube/carapace/internal/shell/spec"
 	"github.com/rsteube/carapace/internal/shell/tcsh"
 	"github.com/rsteube/carapace/internal/shell/xonsh"
 	"github.com/rsteube/carapace/internal/shell/zsh"
 	"github.com/rsteube/carapace/internal/uid"
 	"github.com/rsteube/carapace/pkg/ps"
-	"github.com/rsteube/carapace/pkg/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-// Carapace wraps cobra.Command to define completions
+// Carapace wraps cobra.Command to define completions.
 type Carapace struct {
 	cmd *cobra.Command
 }
 
-// Gen initialized Carapace for given command
+// Gen initialized Carapace for given command.
 func Gen(cmd *cobra.Command) *Carapace {
 	addCompletionCommand(cmd)
 
@@ -77,27 +70,27 @@ func (c Carapace) PreInvoke(f func(cmd *cobra.Command, flag *pflag.Flag, action 
 	}
 }
 
-// PositionalCompletion defines completion for positional arguments using a list of Actions
+// PositionalCompletion defines completion for positional arguments using a list of Actions.
 func (c Carapace) PositionalCompletion(action ...Action) {
 	storage.get(c.cmd).positional = action
 }
 
-// PositionalAnyCompletion defines completion for any positional arguments not already defined
+// PositionalAnyCompletion defines completion for any positional arguments not already defined.
 func (c Carapace) PositionalAnyCompletion(action Action) {
 	storage.get(c.cmd).positionalAny = action
 }
 
-// DashCompletion defines completion for positional arguments after dash (`--`) using a list of Actions
+// DashCompletion defines completion for positional arguments after dash (`--`) using a list of Actions.
 func (c Carapace) DashCompletion(action ...Action) {
 	storage.get(c.cmd).dash = action
 }
 
-// DashAnyCompletion defines completion for any positional arguments after dash (`--`) not already defined
+// DashAnyCompletion defines completion for any positional arguments after dash (`--`) not already defined.
 func (c Carapace) DashAnyCompletion(action Action) {
 	storage.get(c.cmd).dashAny = action
 }
 
-// FlagCompletion defines completion for flags using a map consisting of name and Action
+// FlagCompletion defines completion for flags using a map consisting of name and Action.
 func (c Carapace) FlagCompletion(actions ActionMap) {
 	if e := storage.get(c.cmd); e.flag == nil {
 		e.flag = actions
@@ -108,7 +101,7 @@ func (c Carapace) FlagCompletion(actions ActionMap) {
 	}
 }
 
-// Standalone prevents cobra defaults interfering with standalone mode (e.g. implicit help command)
+// Standalone prevents cobra defaults interfering with standalone mode (e.g. implicit help command).
 func (c Carapace) Standalone() {
 	c.cmd.CompletionOptions = cobra.CompletionOptions{
 		DisableDefaultCmd: true,
@@ -122,7 +115,7 @@ func (c Carapace) Standalone() {
 	c.cmd.SetHelpCommand(&cobra.Command{Hidden: true})
 }
 
-// Snippet creates completion script for given shell
+// Snippet creates completion script for given shell.
 func (c Carapace) Snippet(shell string) (string, error) {
 	if shell == "" {
 		shell = ps.DetermineShell()
@@ -137,7 +130,6 @@ func (c Carapace) Snippet(shell string) (string, error) {
 		"nushell":    nushell.Snippet,
 		"oil":        oil.Snippet,
 		"powershell": powershell.Snippet,
-		"spec":       spec.Snippet,
 		"tcsh":       tcsh.Snippet,
 		"xonsh":      xonsh.Snippet,
 		"zsh":        zsh.Snippet,
@@ -145,214 +137,10 @@ func (c Carapace) Snippet(shell string) (string, error) {
 	if s, ok := shellSnippets[shell]; ok {
 		return s(c.cmd.Root()), nil
 	}
-
-	expected := make([]string, 0)
-	for key := range shellSnippets {
-		expected = append(expected, key)
-	}
-	sort.Strings(expected)
-	return "", fmt.Errorf("expected one of '%v' [was: %v]", strings.Join(expected, "', '"), shell)
+	return "", fmt.Errorf("expected 'bash', bash-ble, 'elvish', 'fish', 'ion', 'nushell', 'oil', 'powershell', 'tcsh', 'xonsh' or 'zsh' [was: %v]", shell)
 }
 
-func lookupFlag(cmd *cobra.Command, arg string) (flag *pflag.Flag) {
-	nameOrShorthand := strings.TrimLeft(strings.SplitN(arg, "=", 2)[0], "-")
-
-	if strings.HasPrefix(arg, "--") {
-		flag = cmd.Flags().Lookup(nameOrShorthand)
-	} else if strings.HasPrefix(arg, "-") && len(nameOrShorthand) > 0 {
-		if pflagfork.IsPosix(cmd.Flags()) {
-			flag = cmd.Flags().ShorthandLookup(string(nameOrShorthand[len(nameOrShorthand)-1]))
-		} else {
-			flag = cmd.Flags().ShorthandLookup(nameOrShorthand)
-		}
-	}
-	return
-}
-
-func addCompletionCommand(cmd *cobra.Command) {
-	for _, c := range cmd.Commands() {
-		if c.Name() == "_carapace" {
-			return
-		}
-	}
-	carapaceCmd := &cobra.Command{
-		Use:    "_carapace",
-		Hidden: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) > 2 && strings.HasPrefix(args[2], "_") {
-				cmd.Hidden = false
-			}
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			logger.Println(os.Args) // TODO replace last with '' if empty
-			if s, err := complete(cmd, args); err != nil {
-				fmt.Fprintln(io.MultiWriter(cmd.OutOrStderr(), logger.Writer()), err.Error())
-			} else {
-				fmt.Fprintln(io.MultiWriter(cmd.OutOrStdout(), logger.Writer()), s)
-			}
-		},
-		FParseErrWhitelist: cobra.FParseErrWhitelist{
-			UnknownFlags: true,
-		},
-		DisableFlagParsing: true,
-	}
-	cmd.AddCommand(carapaceCmd)
-	Carapace{carapaceCmd}.PositionalCompletion(
-		ActionStyledValues(
-			"bash", "#d35673",
-			"bash-ble", "#c2039a",
-			"elvish", "#ffd6c9",
-			"export", style.Default,
-			"fish", "#7ea8fc",
-			"ion", "#0e5d6d",
-			"nushell", "#29d866",
-			"oil", "#373a36",
-			"powershell", "#e8a16f",
-			"spec", style.Default,
-			"tcsh", "#412f09",
-			"xonsh", "#a8ffa9",
-			"zsh", "#efda53",
-		),
-		ActionValues(cmd.Root().Name()),
-	)
-	Carapace{carapaceCmd}.PositionalAnyCompletion(
-		ActionCallback(func(c Context) Action {
-			args := []string{"_carapace", "export", ""}
-			args = append(args, c.Args[2:]...)
-			args = append(args, c.CallbackValue)
-			return ActionExecCommand(uid.Executable(), args...)(func(output []byte) Action {
-				if string(output) == "" {
-					return ActionValues()
-				}
-				return ActionImport(output)
-			})
-		}),
-	)
-
-	styleCmd := &cobra.Command{
-		Use:  "style",
-		Args: cobra.ExactArgs(1),
-		Run:  func(cmd *cobra.Command, args []string) {},
-	}
-	carapaceCmd.AddCommand(styleCmd)
-
-	styleSetCmd := &cobra.Command{
-		Use:  "set",
-		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			for _, arg := range args {
-				if splitted := strings.SplitN(arg, "=", 2); len(splitted) == 2 {
-					if err := style.Set(splitted[0], splitted[1]); err != nil {
-						fmt.Fprint(cmd.ErrOrStderr(), err.Error())
-					}
-				} else {
-					fmt.Fprintf(cmd.ErrOrStderr(), "invalid format: '%v'", arg)
-				}
-			}
-		},
-	}
-	styleCmd.AddCommand(styleSetCmd)
-	Carapace{styleSetCmd}.PositionalAnyCompletion(
-		ActionStyleConfig(),
-	)
-}
-
-func complete(cmd *cobra.Command, args []string) (string, error) {
-	if len(args) == 0 {
-		if s, err := Gen(cmd).Snippet(ps.DetermineShell()); err != nil {
-			fmt.Fprintln(io.MultiWriter(cmd.OutOrStderr(), logger.Writer()), err.Error())
-		} else {
-			fmt.Fprintln(io.MultiWriter(cmd.OutOrStdout(), logger.Writer()), s)
-		}
-	} else {
-		if len(args) == 1 {
-			s, err := Gen(cmd).Snippet(args[0])
-			if err != nil {
-				return "", err
-			}
-			return s, nil
-		} else {
-			shell := args[0]
-			current := args[len(args)-1]
-			previous := args[len(args)-2]
-
-			if err := config.Load(); err != nil {
-				return ActionMessage("failed to load config: "+err.Error()).Invoke(Context{CallbackValue: current}).value(shell, current), nil
-			}
-
-			targetCmd, targetArgs, err := findTarget(cmd, args)
-			if err != nil {
-				return ActionMessage(err.Error()).Invoke(Context{CallbackValue: current}).value(shell, current), nil
-			}
-
-			wd, err := os.Getwd()
-			if err != nil {
-				return ActionMessage(err.Error()).Invoke(Context{CallbackValue: current}).value(shell, current), nil
-			}
-			context := Context{
-				CallbackValue: current,
-				Args:          targetArgs,
-				Env:           os.Environ(),
-				Dir:           wd,
-			}
-			if err != nil {
-				return ActionMessage(err.Error()).Invoke(context).value(shell, current), nil
-			}
-
-			// TODO needs more cleanup and tests
-			var targetAction Action
-			if flag := lookupFlag(targetCmd, previous); !targetCmd.DisableFlagParsing && flag != nil && flag.NoOptDefVal == "" && !common.IsDash(targetCmd) { // previous arg is a flag and needs a value
-				targetAction = storage.getFlag(targetCmd, flag.Name)
-			} else if !targetCmd.DisableFlagParsing && strings.HasPrefix(current, "-") && !common.IsDash(targetCmd) { // assume flag
-				if strings.Contains(current, "=") { // complete value for optarg flag
-					if flag := lookupFlag(targetCmd, current); flag != nil && flag.NoOptDefVal != "" {
-						a := storage.getFlag(targetCmd, flag.Name)
-						splitted := strings.SplitN(current, "=", 2)
-						context.CallbackValue = splitted[1]
-						current = strings.Replace(current, "=", opts.OptArgDelimiter, 1)                  // revert (potentially) overridden optarg divider for `.value()` invocation below
-						targetAction = a.Invoke(context).Prefix(splitted[0] + opts.OptArgDelimiter).ToA() // prefix with (potentially) overridden optarg delimiter
-					}
-				} else { // complete flagnames
-					targetAction = actionFlags(targetCmd)
-				}
-			} else {
-				if len(context.Args) > 0 {
-					context.Args = context.Args[:len(context.Args)-1] // current word being completed is a positional so remove it from context.Args
-				}
-
-				if common.IsDash(targetCmd) {
-					targetAction = findAction(targetCmd, targetArgs[targetCmd.ArgsLenAtDash():])
-				} else {
-					targetAction = findAction(targetCmd, targetArgs)
-					if targetCmd.HasAvailableSubCommands() && len(targetArgs) <= 1 {
-						subcommandA := actionSubcommands(targetCmd).Invoke(context)
-						targetAction = targetAction.Invoke(context).Merge(subcommandA).ToA()
-					}
-				}
-			}
-			return targetAction.Invoke(context).value(shell, current), nil
-		}
-	}
-	return "", nil // TODO
-}
-
-func findAction(targetCmd *cobra.Command, targetArgs []string) Action {
-	// TODO handle Action not found
-	if len(targetArgs) == 0 {
-		return storage.getPositional(targetCmd, 0)
-	}
-	return storage.getPositional(targetCmd, len(targetArgs)-1)
-}
-
-func findTarget(cmd *cobra.Command, args []string) (*cobra.Command, []string, error) {
-	origArg := []string{}
-	if len(args) > 2 {
-		origArg = args[2:]
-	}
-	return common.TraverseLenient(cmd, origArg)
-}
-
-// IsCallback returns true if current program invocation is a callback
+// IsCallback returns true if current program invocation is a callback.
 func IsCallback() bool {
 	return len(os.Args) > 1 && os.Args[1] == "_carapace"
 }
@@ -371,10 +159,10 @@ func initLogger() (err error) {
 	tmpdir := fmt.Sprintf("%v/carapace", os.TempDir())
 	if err = os.MkdirAll(tmpdir, os.ModePerm); err == nil {
 		var logfileWriter io.Writer
-		if logfileWriter, err = os.OpenFile(fmt.Sprintf("%v/%v.log", tmpdir, uid.Executable()), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666); err == nil {
+		if logfileWriter, err = os.OpenFile(fmt.Sprintf("%v/%v.log", tmpdir, uid.Executable()), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666); err == nil {
 			Lmsgprefix := 1 << 6
 			logger = log.New(logfileWriter, ps.DetermineShell()+" ", log.Flags()|Lmsgprefix)
-			//logger = log.New(logfileWriter, determineShell()+" ", log.Flags()|log.Lmsgprefix)
+
 		}
 	}
 	return

--- a/command.go
+++ b/command.go
@@ -1,0 +1,103 @@
+package carapace
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rsteube/carapace/internal/uid"
+	"github.com/rsteube/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+func addCompletionCommand(cmd *cobra.Command) {
+	for _, c := range cmd.Commands() {
+		if c.Name() == "_carapace" {
+			return
+		}
+	}
+
+	carapaceCmd := &cobra.Command{
+		Use:    "_carapace",
+		Hidden: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 2 && strings.HasPrefix(args[2], "_") {
+				cmd.Hidden = false
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			logger.Println(os.Args) // TODO replace last with '' if empty
+			if s, err := complete(cmd, args); err != nil {
+				fmt.Fprintln(io.MultiWriter(cmd.OutOrStderr(), logger.Writer()), err.Error())
+			} else {
+				fmt.Fprintln(io.MultiWriter(cmd.OutOrStdout(), logger.Writer()), s)
+			}
+		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+		DisableFlagParsing: true,
+	}
+
+	cmd.AddCommand(carapaceCmd)
+
+	Carapace{carapaceCmd}.PositionalCompletion(
+		ActionStyledValues(
+			"bash", "#d35673",
+			"bash-ble", "#c2039a",
+			"elvish", "#ffd6c9",
+			"export", style.Default,
+			"fish", "#7ea8fc",
+			"ion", "#0e5d6d",
+			"nushell", "#29d866",
+			"oil", "#373a36",
+			"powershell", "#e8a16f",
+			"spec", style.Default,
+			"tcsh", "#412f09",
+			"xonsh", "#a8ffa9",
+			"zsh", "#efda53",
+		),
+		ActionValues(cmd.Root().Name()),
+	)
+	Carapace{carapaceCmd}.PositionalAnyCompletion(
+		ActionCallback(func(c Context) Action {
+			args := []string{"_carapace", "export", ""}
+			args = append(args, c.Args[2:]...)
+			args = append(args, c.CallbackValue)
+			return ActionExecCommand(uid.Executable(), args...)(func(output []byte) Action {
+				if string(output) == "" {
+					return ActionValues()
+				}
+				return ActionImport(output)
+			})
+		}),
+	)
+
+	styleCmd := &cobra.Command{
+		Use:  "style",
+		Args: cobra.ExactArgs(1),
+		Run:  func(cmd *cobra.Command, args []string) {},
+	}
+	carapaceCmd.AddCommand(styleCmd)
+
+	styleSetCmd := &cobra.Command{
+		Use:  "set",
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, arg := range args {
+				if splitted := strings.SplitN(arg, "=", 2); len(splitted) == 2 {
+					if err := style.Set(splitted[0], splitted[1]); err != nil {
+						fmt.Fprint(cmd.ErrOrStderr(), err.Error())
+					}
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "invalid format: '%v'", arg)
+				}
+			}
+		},
+	}
+	styleCmd.AddCommand(styleSetCmd)
+	Carapace{styleSetCmd}.PositionalAnyCompletion(
+		ActionStyleConfig(),
+	)
+}

--- a/complete.go
+++ b/complete.go
@@ -1,0 +1,199 @@
+package carapace
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rsteube/carapace/internal/common"
+	"github.com/rsteube/carapace/internal/config"
+	"github.com/rsteube/carapace/pkg/ps"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func complete(cmd *cobra.Command, args []string) (string, error) {
+	// Directly skip to snippet generation if
+	// we don't have any arguments to deal with.
+	if len(args) == 0 {
+		outputSnippet(cmd)
+
+		return "", nil
+	}
+
+	// If we have only one argument, its a shell indication/command
+	// for which we must output a completion snippet (to be sourced)
+	if len(args) == 1 {
+		s, err := Gen(cmd).Snippet(args[0])
+		if err != nil {
+			return "", err
+		}
+		return s, nil
+	}
+
+	shell, current, previous := prepareWords(args)
+
+	if configErr := config.Load(); configErr != nil {
+		return ActionMessage("failed to load config: "+configErr.Error()).
+				Invoke(Context{CallbackValue: current}).
+				value(shell, current),
+			nil
+	}
+
+	// Else we are completing the command we've been compiled into.
+	// Any error arising here is returned after creating a context.
+	targetCmd, targetArgs, parseErr := findTarget(cmd, args)
+
+	// Create a new context: it is never nil, even if an error occurs
+	// and is returned from this instantation/setup.
+	ctx, err := newContext(shell, current, targetArgs)
+	if err != nil {
+		return ActionMessage(err.Error()).Invoke(ctx).value(shell, current), nil
+	}
+
+	var action Action
+
+	// unrecoverable command/arg/flag parsing errors are returned immediately.
+	if parseErr != nil {
+		return ActionMessage(parseErr.Error()).Invoke(ctx).value(shell, current), nil
+	}
+
+	// Or we have at least a positional, a flag or a subcommand word to handle.
+	// We simply want to settle on a "root" completion Action, since it can host
+	// an arbitrary tree of child completers/directives.
+	current, action, ctx = getTargetAction(current, previous, ctx, targetCmd, targetArgs)
+
+	// Invoke the completion actions with a context updated/set for the target command.
+	return action.Invoke(ctx).value(shell, current), nil
+}
+
+func getTargetAction(current, previous string, ctx Context, cmd *cobra.Command, args []string) (string, Action, Context) {
+	var targetAction Action
+
+	// If we want an argument for the previous word (-flag)
+	if yes, flag := needsArgument(cmd, previous); yes {
+		return current, storage.getFlag(cmd, flag.Name), ctx
+	}
+
+	// Else we assume that the argument is a flag, trying to split for embedded args
+	if !cmd.DisableFlagParsing && strings.HasPrefix(current, "-") && !common.IsDash(cmd) {
+		return completeOption(cmd, ctx, current, targetAction)
+	}
+
+	// Else, we deal with a positional word (either arg or command)
+	if len(ctx.Args) > 0 {
+		// current word being completed is a positional so remove it from context.Args
+		ctx.Args = ctx.Args[:len(ctx.Args)-1]
+	}
+
+	// If the argument is a DoubleDash that has an impact on how the
+	// remaining arguments will be parsed (usually all in one list)
+	if common.IsDash(cmd) {
+		return current, findAction(cmd, args[cmd.ArgsLenAtDash():]), ctx
+	}
+
+	// Else, we must either consume this arg with one of
+	// our positional arg completers, and/or complete subcommands.
+	targetAction = findAction(cmd, args)
+
+	// We only propose subcommands to complete if we have determined
+	// that we don't have required arguments anymore. Also take account
+	// of if there are still argument completions to provide next.
+	if cmd.HasAvailableSubCommands() && len(args) <= 1 {
+		subcommandA := actionSubcommands(cmd).Invoke(ctx)
+		targetAction = targetAction.Invoke(ctx).Merge(subcommandA).ToA()
+	}
+
+	return current, targetAction, ctx
+}
+
+func completeOption(cmd *cobra.Command, ctx Context, current string, targetAction Action) (string, Action, Context) {
+	// If there is no embedded argument, just parse the next argument word
+	if !strings.Contains(current, "=") {
+		return current, actionFlags(cmd), ctx
+	}
+
+	// If we have found such a split in the string, proceed.
+	// First lookup the flag in the last word.
+	// We must find a flag, or we return an empty Action.
+	flag := lookupFlag(cmd, current)
+	if flag == nil || flag.NoOptDefVal == "" {
+		return current, targetAction, ctx
+	}
+
+	// Else, process the string and build the completion context.
+	action := storage.getFlag(cmd, flag.Name)
+	splitted := strings.SplitN(current, "=", 2)
+	ctx.CallbackValue = splitted[1]
+	current = strings.Replace(current, "=", opts.OptArgDelimiter, 1)                   // revert (potentially) overridden optarg divider for `.value()` invocation below
+	targetAction = action.Invoke(ctx).Prefix(splitted[0] + opts.OptArgDelimiter).ToA() // prefix with (potentially) overridden optarg delimiter
+
+	return current, targetAction, ctx
+}
+
+func findAction(targetCmd *cobra.Command, targetArgs []string) Action {
+	// TODO handle Action not found
+	if len(targetArgs) == 0 {
+		return storage.getPositional(targetCmd, 0)
+	}
+
+	// lastArg := targetArgs[len(targetArgs)-1]
+	// if strings.HasSuffix(lastArg, " ") { // TODO is this still correct/needed?
+	// 	return storage.getPositional(targetCmd, len(targetArgs))
+	// }
+	return storage.getPositional(targetCmd, len(targetArgs)-1)
+}
+
+func findTarget(cmd *cobra.Command, args []string) (*cobra.Command, []string, error) {
+	origArg := []string{}
+	if len(args) > 2 {
+		origArg = args[2:]
+	}
+	return common.TraverseLenient(cmd, origArg)
+}
+
+func lookupFlag(cmd *cobra.Command, arg string) (flag *pflag.Flag) {
+	nameOrShorthand := strings.TrimLeft(strings.SplitN(arg, "=", 2)[0], "-")
+
+	if strings.HasPrefix(arg, "--") {
+		flag = cmd.Flags().Lookup(nameOrShorthand)
+	} else if strings.HasPrefix(arg, "-") && len(nameOrShorthand) > 0 {
+		flag = cmd.Flags().ShorthandLookup(string(nameOrShorthand[len(nameOrShorthand)-1]))
+	}
+	return
+}
+
+func outputSnippet(cmd *cobra.Command) {
+	snip, err := Gen(cmd).Snippet(ps.DetermineShell())
+	if err != nil {
+		fmt.Fprintln(io.MultiWriter(cmd.OutOrStderr(),
+			logger.Writer()),
+			err.Error())
+	} else {
+		fmt.Fprintln(io.MultiWriter(cmd.OutOrStdout(),
+			logger.Writer()),
+			snip)
+	}
+}
+
+func prepareWords(args []string) (shell, current, previous string) {
+	shell = args[0]
+	current = args[len(args)-1]
+	previous = args[len(args)-2]
+
+	return
+}
+
+func needsArgument(targetCmd *cobra.Command, previous string) (yes bool, flag *pflag.Flag) {
+	// We need the flag, non-nil
+	flag = lookupFlag(targetCmd, previous)
+	if flag == nil {
+		return
+	}
+
+	if !targetCmd.DisableFlagParsing && flag.NoOptDefVal == "" && !common.IsDash(targetCmd) {
+		yes = true
+	}
+
+	return
+}

--- a/context.go
+++ b/context.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rsteube/carapace/third_party/golang.org/x/sys/execabs"
 )
 
-// Context provides information during completion
+// Context provides information during completion.
 type Context struct {
 	// CallbackValue contains the (partial) value (or part of it during an ActionMultiParts) currently being completed
 	CallbackValue string
@@ -25,6 +25,27 @@ type Context struct {
 	Dir string
 }
 
+// newContext creates a completion context no matter what, so that any error occurring
+// in its setup can still be returned to the shell caller.
+func newContext(shell, currentCallback string, targetArgs []string) (Context, error) {
+	// Always build a completion ctx so that it can handle
+	// errors accordingly, and a default action, without any settings.
+	ctx := Context{
+		CallbackValue: currentCallback,
+		Args:          targetArgs,
+		Env:           os.Environ(),
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return ctx, err
+	} else {
+		ctx.Dir = wd
+	}
+
+	return ctx, nil
+}
+
 // LookupEnv retrieves the value of the environment variable named by the key.
 func (c *Context) LookupEnv(key string) (string, bool) {
 	prefix := key + "="
@@ -34,7 +55,6 @@ func (c *Context) LookupEnv(key string) (string, bool) {
 		}
 	}
 	return "", false
-
 }
 
 // Getenv retrieves the value of the environment variable named by the key.


### PR DESCRIPTION
This PR aims to refactor the main functions/entrypoints in carapace code.
First of all, thanks a huge lot for this amazing library, much needed.
Wish it all the success.

Note that tests fail on my machine, because I apparently don't have the infrastructure to run them (a bunch of executables not present)

### Completion functions
The completion functions have been refactored in order to eliminate the nested branchings,
add comments to the code so that it is easier to follow for non-initiated, and refactor
the various helper functions (finding target actions, producing completions, etc)

As well, all of these functions related to completion have been moved in the file `complete.go`,
which I unfortunately had to push in the first commit.

### Commands
The `addCompletion()` function, binding the `_carapace` hidden command, has been moved to a file of its own.

### Context
The `context.go` file now has a small constructor, for initializing the context with working directories.
This is only for the sake of clearing the main completion entrypoint code.

### Others
The net result is that `carapace.go` is now stripped from any completion logic code, and command binding.
Only remain most of the public functions, and the logging code.
