### PR TITLE
traverse: allow unknown flags when CARAPACE_LENIENT is set

### DIFF
--- a/example/cmd/action_test.go
+++ b/example/cmd/action_test.go
@@ -163,3 +163,15 @@ func TestAction(t *testing.T) {
 			Expect(carapace.ActionMessage("unknown flag: --unknown"))
 	})
 }
+
+func TestUnknownFlag(t *testing.T) {
+	sandbox.Run(t, "github.com/rsteube/carapace/example")(func(s *sandbox.Sandbox) {
+		s.Run("action", "--unknown", "").
+			Expect(carapace.ActionMessage("unknown flag: --unknown").NoSpace())
+
+		s.Env("CARAPACE_LENIENT", "1")
+		s.Run("action", "--unknown", "").
+			Expect(carapace.ActionValues("p1", "positional1", "positional1 with space").
+				Usage("action [pos1] [pos2] [--] [dashAny]..."))
+	})
+}

--- a/internal/common/traverse.go
+++ b/internal/common/traverse.go
@@ -5,12 +5,26 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/rsteube/carapace/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
+func allowUnknownFlags(cmd *cobra.Command) {
+	cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	}
+	for _, subCmd := range cmd.Commands() {
+		allowUnknownFlags(subCmd)
+	}
+}
+
 // TraverseLenient traverses the command tree but filters errors regarding arguments currently being completed.
 func TraverseLenient(cmd *cobra.Command, args []string) (*cobra.Command, []string, error) {
+	if config.IsLenient() {
+		allowUnknownFlags(cmd.Root())
+	}
+
 	a := args
 
 	// needed so that completion for positional argument that has no value yet to work

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,8 @@
+package config
+
+import "os"
+
+func IsLenient() (lenient bool) {
+	_, lenient = os.LookupEnv("CARAPACE_LENIENT")
+	return
+}

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -18,6 +18,7 @@ import (
 type Sandbox struct {
 	t    *testing.T
 	f    func() *cobra.Command
+	env  map[string]string
 	keep bool
 	mock *common.Mock
 }
@@ -28,8 +29,9 @@ func newSandbox(t *testing.T, f func() *cobra.Command) Sandbox {
 		t.Fatal("failed to create sandbox dir: " + err.Error())
 	}
 	return Sandbox{
-		t: t,
-		f: f,
+		t:   t,
+		f:   f,
+		env: make(map[string]string),
 		mock: &common.Mock{
 			Dir:     tempDir,
 			Replies: make(map[string]string),
@@ -39,6 +41,10 @@ func newSandbox(t *testing.T, f func() *cobra.Command) Sandbox {
 
 func (s *Sandbox) Keep() {
 	s.keep = true
+}
+
+func (s *Sandbox) Env(key, value string) {
+	s.env[key] = value
 }
 
 func (s *Sandbox) remove() {
@@ -128,6 +134,9 @@ func Run(t *testing.T, pkg string) (f func(func(s *Sandbox))) {
 // Run executes the sandbox with given arguments.
 func (s *Sandbox) Run(args ...string) run {
 	c := carapace.NewContext(args)
+	for key, value := range s.env {
+		c.Setenv(key, value)
+	}
 	// TODO actually invoke it here instead of Expect
 	m, _ := json.Marshal(args)
 


### PR DESCRIPTION
fix #611