### PR TITLE
xdg: always use slash as delimiter

### DIFF
--- a/pkg/xdg/xdg.go
+++ b/pkg/xdg/xdg.go
@@ -1,12 +1,16 @@
 package xdg
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // UserCacheDir returns the cache base directory.
 func UserCacheDir() (dir string, err error) {
 	if dir = os.Getenv("XDG_CACHE_HOME"); dir == "" {
 		dir, err = os.UserCacheDir()
 	}
+	dir = filepath.ToSlash(dir)
 	return
 }
 
@@ -15,5 +19,6 @@ func UserConfigDir() (dir string, err error) {
 	if dir = os.Getenv("XDG_CONFIG_HOME"); dir == "" {
 		dir, err = os.UserConfigDir()
 	}
+	dir = filepath.ToSlash(dir)
 	return
 }


### PR DESCRIPTION
related rsteube/carapace-bin#1692