### PR TITLE
API: Export ActionCommands() and ActionFlags() for cobra command

### DIFF
--- a/action.go
+++ b/action.go
@@ -56,6 +56,47 @@ func (a Action) Cache(timeout time.Duration, keys ...pkgcache.Key) Action {
 	return a
 }
 
+// CacheF requires a function to determine if we should use the cached data (if any and if it's
+// still within timeout), and if asked to refresh it, to cache the proceeds of the invoked action.
+func (a Action) CacheF(timeout time.Duration, refresh func() bool, keys ...pkgcache.Key) Action {
+	if a.callback == nil {
+		return a
+	}
+
+	_, file, line, _ := runtime.Caller(1)
+	cachedCallback := a.callback
+
+	return ActionCallback(func(c Context) Action {
+		// Know when the last cached values were written (if any)
+		cacheFile, err := cache.File(file, line, keys...)
+		if err != nil {
+			return a
+		}
+
+		stat, err := os.Stat(cacheFile)
+
+		// No cached results, just ask to cache after call.
+		cacheIsOutdated := (timeout > 0 && stat.ModTime().Add(timeout).Before(time.Now()))
+		if os.IsNotExist(err) || cacheIsOutdated {
+			return a.Cache(timeout, keys...)
+		}
+
+		// If we are asked to refresh the cache with new results anyway, do it.
+		if refresh() {
+			invokedAction := (Action{callback: cachedCallback}).Invoke(c)
+			if invokedAction.meta.Messages.IsEmpty() {
+				if cacheFile, err := cache.File(file, line, keys...); err == nil {
+					_ = cache.Write(cacheFile, invokedAction.export())
+				}
+			}
+			return invokedAction.ToA()
+		}
+
+		// Else, once again let's the cache do it's work.
+		return a.Cache(timeout, keys...)
+	})
+}
+
 // Chdir changes the current working directory to the named directory for the duration of invocation.
 func (a Action) Chdir(dir string) Action {
 	return ActionCallback(func(c Context) Action {
@@ -93,14 +134,14 @@ func (a Action) Filter(values ...string) Action {
 	})
 }
 
-// FilterArgs filters Context.Args
+// FilterArgs filters Context.Args.
 func (a Action) FilterArgs() Action {
 	return ActionCallback(func(c Context) Action {
 		return a.Filter(c.Args...)
 	})
 }
 
-// FilterArgs filters Context.Parts
+// FilterArgs filters Context.Parts.
 func (a Action) FilterParts() Action {
 	return ActionCallback(func(c Context) Action {
 		return a.Filter(c.Parts...)
@@ -141,7 +182,7 @@ func (a Action) MultiParts(dividers ...string) Action {
 	})
 }
 
-// MultiPartsP is like MultiParts but with placeholders
+// MultiPartsP is like MultiParts but with placeholders.
 func (a Action) MultiPartsP(delimiter string, pattern string, f func(placeholder string, matches map[string]string) Action) Action {
 	// TODO add delimiter as suffix for proper nospace handling (some values/placeholders might appear with and without suffix)
 	return ActionCallback(func(c Context) Action {

--- a/traverse.go
+++ b/traverse.go
@@ -147,14 +147,14 @@ loop:
 			return storage.getFlag(c, f.Name).Prefix(f.Prefix), context
 		}
 		LOG.Printf("completing flags for arg %#v\n", context.Value)
-		return actionFlags(c), context
+		return ActionFlags(c), context
 
 	// positional or subcommand
 	default:
 		LOG.Printf("completing positionals and subcommands for arg %#v\n", context.Value)
 		batch := Batch(storage.getPositional(c, len(context.Args)))
 		if c.HasAvailableSubCommands() && len(context.Args) == 0 {
-			batch = append(batch, actionSubcommands(c))
+			batch = append(batch, ActionCommands(c))
 		}
 		return batch.ToA(), context
 	}


### PR DESCRIPTION
### Changes
This PR simply exports the ActionCommands() and ActionFlags() which both receive
a cobra command as argument.

### Reasons
The reason is simple: more and more people will try and succeed (some already do)
in binding/executing cobra commands dynamically, for that very reason might want
to beneficiate from the usual completion utilities, like caching completions.

An example would be a tool of which a significant part of its command tree might
available/unavailable based on different conditions, and rather than having to
always query those on the wire, might just use cached command completions.

### Included commits
- Add a CacheF function force the engine to refresh within timeout if needed.
- Export cobra subcommand/flag completion.

