### PR TITLE
ToMultiParts: keep tag for previous segments

### DIFF
--- a/invokedAction.go
+++ b/invokedAction.go
@@ -120,7 +120,7 @@ func (a InvokedAction) ToMultiPartsA(dividers ...string) Action {
 							Display:     d,
 							Description: "",
 							Style:       "",
-							Tag:         "",
+							Tag:         val.Tag,
 						}
 					}
 				}


### PR DESCRIPTION
This can still be problematic when multiple values have the same prefix,
but a different tag.
Should work for most cases though.
